### PR TITLE
Lock MarkupSafe to 2.0.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,10 +11,11 @@ python_requires = >= 3.8
 include_package_data = True
 packages = find:
 install_requires =
-  ldap3    == 2.8.1
-  psycopg2 == 2.8.6
-  PyYAML   == 5.3.1
-  Jinja2   == 2.11.2
+  ldap3      == 2.8.1
+  psycopg2   == 2.8.6
+  PyYAML     == 5.3.1
+  MarkupSafe == 2.0.1
+  Jinja2     == 2.11.2
 
 [options.package_data]
 * = *.sql, *.j2


### PR DESCRIPTION
Fixes:
- As our version of Jinja2 doesn't lock a version of MarkupSafe, it now breaks because of major version changes. This locks the version of MarkupSafe

**Note:** this is merging into Sendu's branch