### PR TITLE
Root Owned File Fix

### DIFF
--- a/api/persistence/models/file.py
+++ b/api/persistence/models/file.py
@@ -1,7 +1,9 @@
 """
-Copyright (c) 2020 Genome Research Limited
+Copyright (c) 2020, 2022 Genome Research Limited
 
-Author: Christopher Harrison <ch12@sanger.ac.uk>
+Author:
+    - Christopher Harrison <ch12@sanger.ac.uk>
+    - Michael Grace <mg38@sanger.ac.uk>
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the
@@ -32,13 +34,11 @@ class File(persistence.base.File):
 
     device:int
     inode:int
-    path:T.Path
     key:T.Optional[T.Path]
     mtime:T.DateTime
     atime: T.DateTime
     owner:idm.base.User
     group:idm.base.Group
-    size:int
 
     ## Alternative Constructors ########################################
 

--- a/api/vault/__init__.py
+++ b/api/vault/__init__.py
@@ -1,2 +1,3 @@
 from .common import Branch
 from .vault import Vault
+from .file import VaultFile

--- a/core/file.py
+++ b/core/file.py
@@ -4,6 +4,7 @@ Copyright (c) 2020, 2021 Genome Research Limited
 Authors:
 * Christopher Harrison <ch12@sanger.ac.uk>
 * Piyush Ahuja <pa11@sanger.ac.uk>
+* Michael Grace <mg38@sanger.ac.uk>
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the
@@ -24,6 +25,11 @@ import os
 
 from . import time, typing as T
 
+class exception(T.SimpleNamespace):
+    """Namespace of exceptions"""
+
+    class UnactionableFile(Exception):
+        """Raised when a file isn't actionable"""
 
 class BaseFile(metaclass=ABCMeta):
     """ Base class for files """

--- a/core/mail.py
+++ b/core/mail.py
@@ -1,7 +1,9 @@
 """
-Copyright (c) 2020 Genome Research Limited
+Copyright (c) 2020, 2022 Genome Research Limited
 
-Author: Christopher Harrison <ch12@sanger.ac.uk>
+Authors: 
+    - Christopher Harrison <ch12@sanger.ac.uk>
+    - Michael Grace <mg38@sanger.ac.uk>
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the
@@ -48,6 +50,9 @@ class _BaseMessage:
 
 class _BasePostman(metaclass=ABCMeta):
     """ Abstract base class for sending mail """
+    def __init__(self, *args, **kwargs) -> None:
+        ...
+
     def send(self, message:_BaseMessage, *addressee:idm.base.User, addresser:T.Optional[idm.base.User] = None) -> None:
         """
         Send the supplied e-mail message to the appropriate recipients

--- a/core/persistence.py
+++ b/core/persistence.py
@@ -1,7 +1,9 @@
 """
-Copyright (c) 2020 Genome Research Limited
+Copyright (c) 2020, 2022 Genome Research Limited
 
-Author: Christopher Harrison <ch12@sanger.ac.uk>
+Authors: 
+    - Christopher Harrison <ch12@sanger.ac.uk>
+    - Michael Grace <mg38@sanger.ac.uk>
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the
@@ -75,6 +77,8 @@ class _BaseState:
 @dataclass
 class _BaseFile:
     """ Base class for file metadata """
+    path: T.Path
+    size: int
 
 
 class _BaseFileCollection(T.Collection[_BaseFile], T.ContextManager, metaclass=ABCMeta):

--- a/doc/dev/vep/005-FailingOnUnactionableFiles/design.md
+++ b/doc/dev/vep/005-FailingOnUnactionableFiles/design.md
@@ -1,0 +1,37 @@
+# Vault Enhancement Proposal 5: Failing on Unactionable Files
+
+## Current Behaviour
+
+*Originally defined in the [design document](/doc/dev/design.md).*
+
+When the batch process is run, it will collect all the files it needs to action on, and inform the owner about the actions it is going to do, for example: soft-deleting the file.
+
+> For each user, collate the lists of files scheduled for deletion, files deleted and files staged for archival and use them to render and send an appropriate e-mail
+
+It is important to note that the batch process is designed to fail if anything goes wrong, to attempt to stop any unwanted data loss.
+
+## Proposed Behaviour
+
+### Bug
+
+This VEP is designed to resolve the bug identified in [issue #18](https://github.com/wtsi-hgi/hgi-vault/issues/18).
+
+Some files are owned by `root`, such as ones created by ISG.
+
+Files in a HGI managed area on Lustre typically are properly owned by the right user and are part of the right group, however some files, such as `wrstat` files are owned by the `root` user (ID `0`). The batch process attempts to look up the user ID `0` in the LDAP records to email the right person, and can't find the user, therefore it fails.
+
+Although ideally files shouldn't be owned by the root user, it is a possibilty we need to deal with.
+
+### Solution
+
+- We need Sandman to fail earlier if it comes across a file owned by root. When we first discover that a file can't be actioned on, we should issue a `CRITICAL` message, and exit. This will be a more graceful exit than just letting the process continue until it fails to find the user ID `0` in the LDAP records.
+- Whether a file can be actioned on can be determined using `VaultFile.can_add`.
+
+### Discussion
+
+- Although this was originally an issue due to a file owned by `root`, there are other situations this could arise from - such as incorrect permissions set on the files. As `can_add` includes a variety of checks, this can work in other situations too.
+- By failing earlier in the process, there is less oppurtunity for unexpected behaviour, which could include data loss.
+- Failing in this instance rather than skipping the file also helps stop unexpected failures - for instance it may still delete the file without warning anybody, so this stops that.
+- If Sandman fails due to a file owned by `root`, or other issues regarding file permissions/file owners, we have the oppurtunity to stop Sandman whilst we resolve these problems the proper way by changing owners/permissions.
+- However, this does mean that Sandman will fail every time it is run between the first time it has to action these files and when we resolve the issue.
+- Missed Sandman runs can potentially lead to data loss without the ideal amount of warning, however this can be addressed alongside [issue #6](https://github.com/wtsi-hgi/hgi-vault/issues/6).

--- a/eg/__init__.py
+++ b/eg/__init__.py
@@ -1,0 +1,1 @@
+from .mock_mailer import MockMailer

--- a/eg/mock_mailer.py
+++ b/eg/mock_mailer.py
@@ -1,0 +1,49 @@
+"""
+Copyright (c) 2021 Genome Research Limited
+
+Authors:
+* Michael Grace <mg38@sanger.ac.uk>
+
+This program is free software: you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see https://www.gnu.org/licenses/
+"""
+
+"""
+If you are working with Sandman, you can
+save sending emails by temporarily replacing
+the postman in the sweeper with this class.
+It writes any "emails" to /tmp/mail
+"""
+
+from pathlib import Path
+from core import mail, typing as T
+
+class MockMailer(mail.base.Postman):
+    """
+    Provides a class for "sending" emails
+    without actually sending them
+    """
+
+    file_path: T.Path = Path("/tmp/mail")
+    
+    @property
+    def addresser(self) -> str:
+        return "fake-emailer@sanger.ac.uk"
+
+    def _deliver(self, message: mail.base.Message, recipients: T.Collection[str], sender: str) -> None:
+        with open(self.__class__.file_path, "w") as f:
+            f.write(f"Subject: {message.subject}\n")
+            f.write(f"To: {', '.join(recipients)}\n")
+            f.write(f"From: {sender}\n")
+            f.write("\n")
+            f.write(message.body)

--- a/test/api/vault/mock_file.py
+++ b/test/api/vault/mock_file.py
@@ -1,0 +1,79 @@
+"""
+Copyright (c) 2021 Genome Research Limited
+
+Authors: 
+    * Michael Grace <mg38@sanger.ac.uk>
+
+This program is free software: you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see https://www.gnu.org/licenses/
+"""
+
+from core.typing import PosixPath
+import api.vault
+
+
+class _MockOtherUserOwnedFile(PosixPath):
+    """
+    In a testing environment, we can't simulate files being owned by other
+    users, as we need root permissions to change the file owner.
+
+    Therefore, in some test cases we'll use this class which inherits
+    the majority of its methods from pathlib.PosixPath, except the stat()
+    method, which allows us to artificially change the owner and group
+    """
+    class _StatResult:
+        """_StatResult allows the individual parts of a stat() call to
+        be accessed, including our fake owner and group info."""
+        def __init__(self, stats, id) -> None:
+            self.st_gid = id
+            self.st_uid = id
+            self.st_mode = stats.st_mode
+            self.st_ino = stats.st_ino
+
+    def __new__(cls, _, *args, **kwargs):
+        return PosixPath.__new__(_MockOtherUserOwnedFile, *args, **kwargs)
+
+    def __init__(self, id, *_) -> None:
+        self.id: int = id
+        super().__init__()
+
+    def stat(self):
+        """stat() overrides the PosixPath's version, allowing
+        us to return whatever stat result we want
+        
+        We check if the object has the `id` attribute first, because
+        the PosixPath class may attempt to create more instances of
+        this class, not knowing it needs a fake user/group id
+        """
+        if not hasattr(self, 'id'):
+            self.id = super().stat().st_uid
+
+        return self._StatResult(super().stat(), self.id)
+
+
+class MockRootOwnedVaultFile(api.vault.VaultFile):
+    """MockRootOwnedVaultFile extends VaultFile, overriding
+    the source property, which gives a _MockOtherUserOwnedFile
+    """
+    @property
+    def source(self):
+        return _MockOtherUserOwnedFile(0, super().source) # 0 is root user UID
+
+
+class MockOtherUserOwnedVaultFile(api.vault.VaultFile):
+    """MockOtherUserOwnedVaultFile extends VaultFile, overriding
+    the source property, which gives a _MockOtherUserOwnedFile
+    """
+    @property
+    def source(self):
+        return _MockOtherUserOwnedFile(-1, super().source) # -1 will never be current UID

--- a/test/core/test_file.py
+++ b/test/core/test_file.py
@@ -1,9 +1,10 @@
 """
-Copyright (c) 2020, 2021 Genome Research Limited
+Copyright (c) 2020, 2021, 2022 Genome Research Limited
 
 Authors:
 * Christopher Harrison <ch12@sanger.ac.uk>
 * Piyush Ahuja <pa11@sanger.ac.uk>
+* Michael Grace <mg38@sanger.ac.uk>
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the
@@ -72,9 +73,9 @@ class TestFile(unittest.TestCase):
 
         before = int(time.timestamp(time.now()))
         file.touch(tmp_file)
+        _stat = tmp_file.stat()
         after = int(time.timestamp(time.now()))
 
-        _stat = tmp_file.stat()
         atime = int(_stat.st_atime)
         mtime = int(_stat.st_mtime)
 


### PR DESCRIPTION
Might as well actually open this as a PR as these are now what we're doing (even if I did code this in November then we all got distracted).

Fixes: #18 

- Files owned by the root user can't be actioned by Sandman - this should fail when the file is found, not when it tries to send an email to them
- Also introduces a MockMailer class if you want to test sending emails

As this was coded so long ago, there are conflicts. I'll sort those :) 