### PR TITLE
File age is now the greater of mtime and atime.

### DIFF
--- a/api/persistence/models/file.py
+++ b/api/persistence/models/file.py
@@ -35,6 +35,7 @@ class File(persistence.base.File):
     path:T.Path
     key:T.Optional[T.Path]
     mtime:T.DateTime
+    atime: T.DateTime
     owner:idm.base.User
     group:idm.base.Group
     size:int
@@ -50,6 +51,7 @@ class File(persistence.base.File):
                    path   = path,
                    key    = None,
                    mtime  = time.epoch(stat.st_mtime),
+                   atime  = time.epoch(stat.st_atime),
                    owner  = idm.user(uid=stat.st_uid),
                    group  = idm.group(gid=stat.st_gid),
                    size   = stat.st_size)
@@ -92,6 +94,7 @@ class File(persistence.base.File):
     def __eq__(self, other:File) -> bool:
         """ Equality predicate """
         # We don't care if the vault keys don't match
+        # *** need test for this needing atime check as well
         return self.device == other.device \
            and self.inode  == other.inode \
            and self.path   == other.path \

--- a/api/persistence/models/file.py
+++ b/api/persistence/models/file.py
@@ -99,6 +99,7 @@ class File(persistence.base.File):
            and self.inode  == other.inode \
            and self.path   == other.path \
            and self.mtime  == other.mtime \
+           and self.atime  == other.atime \
            and self.owner  == other.owner \
            and self.group  == other.group \
            and self.size   == other.size

--- a/bin/sandman/walk.py
+++ b/bin/sandman/walk.py
@@ -68,12 +68,12 @@ class File(file.BaseFile):
     @classmethod
     def FromStat(cls, path:T.Path, stat:os.stat_result, timestamp:T.DateTime) -> File:
         """ Construct from explicit stat data """
-        # *** need test for needing to set atime in here as well
         file = models.File(device = stat.st_dev,
                            inode  = stat.st_ino,
                            path   = path,
                            key    = None,
                            mtime  = time.epoch(stat.st_mtime),
+                           atime  = time.epoch(stat.st_atime),
                            owner  = idm.user(uid=stat.st_uid),
                            group  = idm.group(gid=stat.st_gid),
                            size   = stat.st_size)

--- a/bin/sandman/walk.py
+++ b/bin/sandman/walk.py
@@ -68,6 +68,7 @@ class File(file.BaseFile):
     @classmethod
     def FromStat(cls, path:T.Path, stat:os.stat_result, timestamp:T.DateTime) -> File:
         """ Construct from explicit stat data """
+        # *** need test for needing to set atime in here as well
         file = models.File(device = stat.st_dev,
                            inode  = stat.st_ino,
                            path   = path,
@@ -89,7 +90,7 @@ class File(file.BaseFile):
     @property
     def age(self) -> T.TimeDelta:
         self.restat()
-        return time.now() - self._file.mtime
+        return time.now() - max([self._file.mtime, self._file.atime])
 
     @property
     def locked(self) -> bool:


### PR DESCRIPTION
Changed:
* bin/sandman/walk/File.age is now the greater of mtime and atime.

This ought to impact 2 other areas, but tests not written for those.