### PR TITLE
Vault subcommand takes fofn as input 

### DIFF
--- a/bin/common.py
+++ b/bin/common.py
@@ -27,7 +27,7 @@ from api.logging import log
 
 # Executable versioning
 class version(T.SimpleNamespace):
-    vault   = "0.0.8"
+    vault   = "0.0.9"
     sandman = "0.0.7"
 
 

--- a/bin/vault/__init__.py
+++ b/bin/vault/__init__.py
@@ -201,7 +201,7 @@ _view_contexts = {
 
 def main(argv: T.List[str] = sys.argv) -> None:
     args = usage.parse_args(argv[1:])
-    
+        
     # Note: Actions do not map 1:1 to branches
     # e.g. "archive" action can map to Stash or Staged branches.
     if args.action == "keep":
@@ -210,13 +210,7 @@ def main(argv: T.List[str] = sys.argv) -> None:
         else:
             if args.files:
                 add(Branch.Keep, args.files)
-            elif fofn:= args.fofn:
-                with open(fofn) as file:
-                    while filepath := file.readline():
-                        resolved_path = T.Path(filepath.rstrip()).resolve()
-                        if resolved_path.is_symlink():
-                            log.warning(f"{path} is a symlink. Acting on the original file: {resolved_path}")
-                        add(Branch.Keep, [resolved_path])
+          
 
     if args.action == "archive":
         if context := args.view:
@@ -231,37 +225,14 @@ def main(argv: T.List[str] = sys.argv) -> None:
                 branch = Branch.Archive
             if args.files:
                 add(branch, args.files)
-            elif fofn:= args.fofn:
-                with open(fofn) as file:
-                    while filepath := file.readline():
-                        resolved_path = T.Path(filepath.rstrip()).resolve()
-                        if resolved_path.is_symlink():
-                            log.warning(f"{path} is a symlink. Acting on the original file: {resolved_path}")
-                        add(branch, [resolved_path])
           
 
     if args.action == "recover":
         if context := args.view:
             view(Branch.Limbo, _view_contexts[context], args.absolute)
         else: 
-            if fofn:= args.fofn:
-                with open(fofn) as file:
-                    while filepath := file.readline():
-                        resolved_path = T.Path(filepath.rstrip()).resolve()
-                        if resolved_path.is_symlink():
-                            log.warning(f"{path} is a symlink. Acting on the original file: {resolved_path}")
-                        recover([resolved_path])
-            else:
-                 recover(None if args.all else args.files)
+           recover(None if args.all else args.files)
             
 
     if args.action == "untrack":
-        if fofn:= args.fofn:
-                with open(fofn) as file:
-                    while filepath := file.readline():
-                        resolved_path = T.Path(filepath.rstrip()).resolve()
-                        if resolved_path.is_symlink():
-                            log.warning(f"{path} is a symlink. Acting on the original file: {resolved_path}")
-                        untrack([resolved_path])
-        else:
-            untrack(args.files)
+        untrack(args.files)

--- a/bin/vault/__init__.py
+++ b/bin/vault/__init__.py
@@ -218,27 +218,30 @@ _view_contexts = {
 
 def main(argv: T.List[str] = sys.argv) -> None:
     args = usage.parse_args(argv[1:])
-    staged = False
-   
-    if args.action in _action_to_branch.keys():
-        #Map our action and behaviour to a branch
-      
-        branch = _action_to_branch[args.action]
-        if args.action == "archive":
-            if args.view_staged:
-                staged=True
-            branch = branch[(args.stash, staged)]
 
-        # VIEW requests: Are we viewing?
-        if context := (args.view or (args.action == "archive" and args.view_staged)):
-            view(branch, _view_contexts[context], args.absolute)
-            if args.action == "archive" and not args.view_staged:
-                view(Branch.Stash, _view_contexts[context], args.absolute)
-        # otherwise
+    if args.action == "keep":
+        if context := args.view:
+            view(Branch.Keep, _view_contexts[context], args.absolute)
         else:
-            if args.action == "recover":
-                recover(None if args.all else args.files)
+            add(Branch.Keep, args.files)
+
+    if args.action == "archive":
+        if context := args.view:
+            view(Branch.Archive, _view_contexts[context], args.absolute)
+            view(Branch.Stash, _view_contexts[context], args.absolute)
+        elif context := args.view_staged:
+            view(Branch.Staged, _view_contexts[context], args.absolute)
+        else: 
+            if args.stash:
+                add(Branch.Stash, args.files)
             else:
-                add(branch, args.files)
-    else:
+                add(Branch.Archive, args.files)
+
+    if args.action == "recover":
+        if context := args.view:
+            view(Branch.Limbo, _view_contexts[context], args.absolute)
+        else:
+            recover(None if args.all else args.files)
+
+    if args.action == "untrack":
         untrack(args.files)

--- a/bin/vault/__init__.py
+++ b/bin/vault/__init__.py
@@ -89,7 +89,7 @@ def view(branch: Branch, view_mode: ViewContext, absolute: bool) -> None:
         else ''}""")
 
 
-def add(branch: Branch, files: T.List[T.Path]) -> None:
+def add(branch: Branch, files: T.Iterable[T.Path]) -> None:
     """ Add the given files to the appropriate branch """
     for f in files:
         if not file.is_regular(f):
@@ -115,7 +115,7 @@ def add(branch: Branch, files: T.List[T.Path]) -> None:
             log.error(f"Cannot add: {e}")
 
 
-def untrack(files: T.List[T.Path]) -> None:
+def untrack(files: T.Iterable[T.Path]) -> None:
     """ Untrack the given files """
     for f in files:
         if not file.is_regular(f):
@@ -149,7 +149,7 @@ def untrack(files: T.List[T.Path]) -> None:
                 pass
 
 
-def recover(files: T.Optional[T.List[T.Path]] = None) -> None:
+def recover(files: T.Optional[T.Iterable[T.Path]] = None) -> None:
     """
     Recover the given files from Limbo branch or Recover all files from
     the Limbo branch

--- a/bin/vault/__init__.py
+++ b/bin/vault/__init__.py
@@ -216,7 +216,7 @@ def main(argv: T.List[str] = sys.argv) -> None:
                         resolved_path = T.Path(filepath.rstrip()).resolve()
                         if resolved_path.is_symlink():
                             log.warning(f"{path} is a symlink. Acting on the original file: {resolved_path}")
-                        add(Branch.Keep, resolved_path)
+                        add(Branch.Keep, [resolved_path])
 
     if args.action == "archive":
         if context := args.view:
@@ -237,7 +237,7 @@ def main(argv: T.List[str] = sys.argv) -> None:
                         resolved_path = T.Path(filepath.rstrip()).resolve()
                         if resolved_path.is_symlink():
                             log.warning(f"{path} is a symlink. Acting on the original file: {resolved_path}")
-                        add(branch, resolved_path)
+                        add(branch, [resolved_path])
           
 
     if args.action == "recover":
@@ -250,7 +250,7 @@ def main(argv: T.List[str] = sys.argv) -> None:
                         resolved_path = T.Path(filepath.rstrip()).resolve()
                         if resolved_path.is_symlink():
                             log.warning(f"{path} is a symlink. Acting on the original file: {resolved_path}")
-                        recover(resolved_path)
+                        recover([resolved_path])
             else:
                  recover(None if args.all else args.files)
             
@@ -262,6 +262,6 @@ def main(argv: T.List[str] = sys.argv) -> None:
                         resolved_path = T.Path(filepath.rstrip()).resolve()
                         if resolved_path.is_symlink():
                             log.warning(f"{path} is a symlink. Acting on the original file: {resolved_path}")
-                        untrack(resolved_path)
+                        untrack([resolved_path])
         else:
             untrack(args.files)

--- a/bin/vault/usage.py
+++ b/bin/vault/usage.py
@@ -87,16 +87,26 @@ def _parser_factory():
                 nargs="?",
                 const="all",
                 help=_actions[action].view_help)
+
     sub_parser.add_argument(
                 "--absolute",
                 action="store_true",
                 help=_absolute_help
     )
+
+    
+    sub_parser.add_argument(
+            "--fofn",
+            nargs="?",
+            type=T.Path,
+            help=f"file of file names to archive",
+            metavar="FOFN")
+
     sub_parser.add_argument(
             "files",
             nargs="*",
             type=T.Path,
-            help=f"file to keep (at most 10)",
+            help=f"file to archive (at most 10)",
             metavar="FILE")
 
 
@@ -128,6 +138,15 @@ def _parser_factory():
                 action="store_true",
                 help=_absolute_help
     )
+
+   
+    sub_parser.add_argument(
+            "--fofn",
+            nargs="?",
+            type=T.Path,
+            help=f"file of file names to archive",
+            metavar="FOFN")
+
     sub_parser.add_argument(
             "files",
             nargs="*",
@@ -135,20 +154,7 @@ def _parser_factory():
             help=f"file to archive (at most 10)",
             metavar="FILE")
     
-    
-    
-
-
-    action = "untrack"
-    sub_parser = sub_level.add_parser(action, help= _actions[action].help)
-    sub_parser.add_argument(
-            "files",
-            nargs="+",
-            type=T.Path,
-            help=f"file to untrack",
-            metavar="FILE")
-
-
+   
     action = "recover"
     sub_parser = sub_level.add_parser(action, help= _actions[action].help)
     sub_parser.usage = _actions[action].usage
@@ -170,12 +176,42 @@ def _parser_factory():
                 action="store_true",
                 help="recover all recoverable files")
 
+   
+    sub_parser.add_argument(
+            "--fofn",
+            nargs="?",
+            type=T.Path,
+            help=f"file of file names to archive",
+            metavar="FOFN")
+
     sub_parser.add_argument(
             "files",
             nargs="*",
             type=T.Path,
-            help=f"file to recover",
+            help=f"file to archive (at most 10)",
             metavar="FILE")
+
+
+
+    action = "untrack"
+    sub_parser = sub_level.add_parser(action, help= _actions[action].help)
+
+    sub_parser.add_argument(
+            "--fofn",
+            nargs="?",
+            type=T.Path,
+            help=f"file of file names to archive",
+            metavar="FOFN")
+
+    sub_parser.add_argument(
+            "files",
+            nargs="*",
+            type=T.Path,
+            help=f"file to untrack",
+            metavar="FILE")
+
+
+
 
 
     def parser(args:T.List[str]) -> argparse.Namespace:
@@ -186,10 +222,11 @@ def _parser_factory():
         if parsed.action == "keep":
             if parsed.view:
                 del parsed.files
+                del parsed.fofn
             else:
                 if parsed.absolute:
                     action_level[parsed.action].error("you must use --view flag to use --absolute flag")
-                if not parsed.files:
+                if not parsed.files and not parsed.fofn:
                     action_level[parsed.action].error(_actions[parsed.action].args_error)
                 elif len(parsed.files) > 10:
                     # Limit number of files to at most 10
@@ -198,10 +235,11 @@ def _parser_factory():
         if parsed.action == "archive":
             if parsed.view or parsed.view_staged:
                 del parsed.files
+                del parsed.fofn
             else:
                 if parsed.absolute:
                     action_level[parsed.action].error("you must use --view flag or --view-staged flag to use --absolute flag")
-                if not parsed.files:
+                if not parsed.files and not parsed.fofn:
                     action_level[parsed.action].error(_actions[parsed.action].args_error)
                 elif len(parsed.files) > 10:
                     # Limit number of files to at most 10
@@ -215,7 +253,7 @@ def _parser_factory():
             else:
                 if parsed.absolute:
                     action_level[parsed.action].error("you must use --view flag to use --absolute flag")
-                if not parsed.files:
+                if not parsed.files and not parsed.fofn:
                     action_level[parsed.action].error(_actions[parsed.action].args_error)
 
         # NOTE There is no special case for the "untrack" action

--- a/doc/dev/vep/005-FofnInput/design.md
+++ b/doc/dev/vep/005-FofnInput/design.md
@@ -1,0 +1,62 @@
+# Vault Enhancement Proposal 5: Fofn Input
+
+## Current Behaviour
+
+_Originally defined in the [design document](/doc/dev/design.md)._
+
+A file is added to a branch  of a vault (`keep` or `archive` or `stash`) or recovered from `limbo` branch or untracked using the following command:
+
+    vault ACTION FILE(s)..
+
+where ACTION could be `keep` or `archive` or `archive --stash` or `recover` or `untrack`.
+
+
+The FILE(s) argument must satisfy the following:
+
+* At least one file path must be passed.
+* The number of paths in the list can be at most 10 if ACTION is `keep` or `archive`
+* The paths can be either relative to the current working directory or absolute. 
+* The files in the paths should be regular files (i.e. they cannot be directories or symlinks). 
+* Users are advised to be mindful of what they annotate and do it explicitly. While passing a glob file pattern as an argument is allowed, however, if the glob evaluates to more than 10 files the annotation will fail as the number of paths in the list are limited to 10 (`keep` or `archive`)
+
+
+
+## Proposed Behaviour
+
+
+This work should be done in `feature/fofn-input` branch.
+
+In all those instances where vault takes as input a filepath (or a list of file paths), it will take an additional, optional flag  `--fofn` that will take a fofn filepath as argument.
+
+Example:
+
+```
+vault keep --help
+                | --view [CONTEXT] [--absolute]
+                | --view-staged [CONTEXT] [--absolute]
+                | [--stash] FILE [FILE...]
+                | --fofn FILE
+```
+
+```
+vault archive --help
+                | --view [CONTEXT] [--absolute]
+                | --view-staged [CONTEXT] [--absolute]
+                | [--stash] FILE [FILE...]
+                | --fofn FILE
+```
+
+```
+vault recover --help
+                | --view  [CONTEXT] [--absolute] 
+                | --all 
+                | FILE(s)...  
+                | --fofn FILE
+```
+
+```
+vault untrack --help
+                | FILE(s)...  
+                | --fofn FILE
+```
+

--- a/doc/dev/vep/005-FofnInput/design.md
+++ b/doc/dev/vep/005-FofnInput/design.md
@@ -33,30 +33,29 @@ Example:
 ```
 vault keep --help
                 | --view [CONTEXT] [--absolute]
-                | --view-staged [CONTEXT] [--absolute]
-                | [--stash] FILE [FILE...]
-                | --fofn FILE
+                | FILE [FILE(s)...] 
+                | --fofn FOFN          
 ```
 
 ```
 vault archive --help
                 | --view [CONTEXT] [--absolute]
                 | --view-staged [CONTEXT] [--absolute]
-                | [--stash] FILE [FILE...]
-                | --fofn FILE
+                | [--stash] FILE [FILE(s)...] 
+                | [--stash]  --fofn FOFN       
 ```
 
 ```
 vault recover --help
                 | --view  [CONTEXT] [--absolute] 
                 | --all 
-                | FILE(s)...  
-                | --fofn FILE
+                | FILE [FILE(s)...]    
+                | --fofn FOFN      
 ```
 
 ```
 vault untrack --help
                 | FILE(s)...  
-                | --fofn FILE
+                | --fofn FOFN
 ```
 

--- a/doc/dev/vep/005-FofnInput/review-05.md
+++ b/doc/dev/vep/005-FofnInput/review-05.md
@@ -1,0 +1,14 @@
+# VEP005 Review
+
+## General
+
+The changes look good; 
+
+### bin/vault/usage.py
+https://github.com/wtsi-hgi/hgi-vault/blob/8f8d66d6de21ff8ed579b9bf0cede071a11826ab/bin/vault/usage.py
+
+* L281: Typing could be added to the `def` of `_create_fofn_generator` function.
+* L286-287: testing with a symlink in the fofn, the warning didn't show.
+* should tests be added for symlinks in the fofn?
+  
+

--- a/test/bin/vault/test_main.py
+++ b/test/bin/vault/test_main.py
@@ -100,18 +100,8 @@ class TestMain(unittest.TestCase):
     @mock.patch('bin.vault.add')
     def test_keep_fofn(self, mock_add, mock_remove, mock_file):
         main(["__init__","keep" ,"--fofn", "mock_file"])
-        calls = [call(Branch.Keep, T.Path("/file1")), 
-                 call(Branch.Keep, T.Path("/file2"))]
-        mock_add.assert_has_calls(calls)
-        mock_remove.assert_not_called()
-
-    @mock.patch("builtins.open", new_callable=mock_open, read_data='/file1\n/file2')
-    @mock.patch('bin.vault.untrack')
-    @mock.patch('bin.vault.add')
-    def test_keep_fofn(self, mock_add, mock_remove, mock_file):
-        main(["__init__","keep" , "--fofn", "mock_file"])
-        calls = [call(Branch.Keep, T.Path("/file1")), 
-                 call(Branch.Keep, T.Path("/file2"))]
+        calls = [call(Branch.Keep, [T.Path("/file1")]), 
+                 call(Branch.Keep, [T.Path("/file2")])]
         mock_add.assert_has_calls(calls)
         mock_remove.assert_not_called()
 
@@ -257,8 +247,8 @@ class TestMain(unittest.TestCase):
     @mock.patch('bin.vault.add')
     def test_archive_fofn(self, mock_add, mock_remove, mock_file):
         main(["__init__","archive" ,"--fofn", "mock_file"])
-        calls = [call(Branch.Archive, T.Path("/file1")), 
-                 call(Branch.Archive, T.Path("/file2"))]
+        calls = [call(Branch.Archive, [T.Path("/file1")]), 
+                 call(Branch.Archive, [T.Path("/file2")])]
         mock_add.assert_has_calls(calls)
         mock_remove.assert_not_called()
 
@@ -267,8 +257,8 @@ class TestMain(unittest.TestCase):
     @mock.patch('bin.vault.add')
     def test_archive_stash_fofn(self, mock_add, mock_remove, mock_file):
         main(["__init__","archive" ,"--stash", "--fofn", "mock_file"])
-        calls = [call(Branch.Stash, T.Path("/file1")), 
-                 call(Branch.Stash, T.Path("/file2"))]
+        calls = [call(Branch.Stash, [T.Path("/file1")]), 
+                 call(Branch.Stash, [T.Path("/file2")])]
         mock_add.assert_has_calls(calls)
         mock_remove.assert_not_called()
 
@@ -301,8 +291,8 @@ class TestMain(unittest.TestCase):
     @mock.patch('bin.vault.recover')
     def test_recover_fofn(self, mock_recover, mock_remove, mock_file):
         main(["__init__","recover", "--fofn", "mock_file"])
-        calls = [call(T.Path("/file1")), 
-                 call(T.Path("/file2"))]
+        calls = [call([T.Path("/file1")]), 
+                 call([T.Path("/file2")])]
         mock_recover.assert_has_calls(calls)
         mock_remove.assert_not_called()
 
@@ -314,8 +304,8 @@ class TestMain(unittest.TestCase):
 
     @mock.patch("builtins.open", new_callable=mock_open, read_data='/file1\n/file2\n')
     @mock.patch('bin.vault.untrack')
-    def test_untrack(self, mock_untrack, mock_file):
+    def test_untrack_fofn(self, mock_untrack, mock_file):
         main(["__init__","untrack" ,"--fofn", "mock_file"])
-        calls = [call(T.Path("/file1")), 
-                 call(T.Path("/file2"))]
+        calls = [call([T.Path("/file1")]), 
+                 call([T.Path("/file2")])]
         mock_untrack.assert_has_calls(calls)

--- a/test/bin/vault/test_main.py
+++ b/test/bin/vault/test_main.py
@@ -20,7 +20,7 @@ with this program. If not, see https://www.gnu.org/licenses/
 """
 import unittest
 from unittest import mock
-from unittest.mock import call
+from unittest.mock import call, mock_open
 
 import os
 os.environ["VAULTRC"] = "eg/.vaultrc"
@@ -94,6 +94,27 @@ class TestMain(unittest.TestCase):
         main(["__init__","keep" ,"/file1", "/file2"])
         mock_add.assert_called_with(Branch.Keep, [T.Path("/file1"), T.Path("/file2")])
         mock_remove.assert_not_called()
+
+    @mock.patch("builtins.open", new_callable=mock_open, read_data='/file1\n/file2')
+    @mock.patch('bin.vault.untrack')
+    @mock.patch('bin.vault.add')
+    def test_keep_fofn(self, mock_add, mock_remove, mock_file):
+        main(["__init__","keep" ,"--fofn", "mock_file"])
+        calls = [call(Branch.Keep, T.Path("/file1")), 
+                 call(Branch.Keep, T.Path("/file2"))]
+        mock_add.assert_has_calls(calls)
+        mock_remove.assert_not_called()
+
+    @mock.patch("builtins.open", new_callable=mock_open, read_data='/file1\n/file2')
+    @mock.patch('bin.vault.untrack')
+    @mock.patch('bin.vault.add')
+    def test_keep_fofn(self, mock_add, mock_remove, mock_file):
+        main(["__init__","keep" , "--fofn", "mock_file"])
+        calls = [call(Branch.Keep, T.Path("/file1")), 
+                 call(Branch.Keep, T.Path("/file2"))]
+        mock_add.assert_has_calls(calls)
+        mock_remove.assert_not_called()
+
 
     @mock.patch('bin.vault.untrack')
     @mock.patch('bin.vault.view')
@@ -231,6 +252,26 @@ class TestMain(unittest.TestCase):
         mock_add.assert_called_with(Branch.Archive, [T.Path("/file1"), T.Path("/file2")])
         mock_remove.assert_not_called()
 
+    @mock.patch("builtins.open", new_callable=mock_open, read_data='/file1\n/file2')
+    @mock.patch('bin.vault.untrack')
+    @mock.patch('bin.vault.add')
+    def test_archive_fofn(self, mock_add, mock_remove, mock_file):
+        main(["__init__","archive" ,"--fofn", "mock_file"])
+        calls = [call(Branch.Archive, T.Path("/file1")), 
+                 call(Branch.Archive, T.Path("/file2"))]
+        mock_add.assert_has_calls(calls)
+        mock_remove.assert_not_called()
+
+    @mock.patch("builtins.open", new_callable=mock_open, read_data='/file1\n/file2')
+    @mock.patch('bin.vault.untrack')
+    @mock.patch('bin.vault.add')
+    def test_archive_stash_fofn(self, mock_add, mock_remove, mock_file):
+        main(["__init__","archive" ,"--stash", "--fofn", "mock_file"])
+        calls = [call(Branch.Stash, T.Path("/file1")), 
+                 call(Branch.Stash, T.Path("/file2"))]
+        mock_add.assert_has_calls(calls)
+        mock_remove.assert_not_called()
+
 
     @mock.patch('bin.vault.untrack')
     @mock.patch('bin.vault.add')
@@ -255,7 +296,26 @@ class TestMain(unittest.TestCase):
         mock_recover.assert_called_with(None)
         mock_untrack.assert_not_called()
 
+    @mock.patch("builtins.open", new_callable=mock_open, read_data='/file1\n/file2\n')
+    @mock.patch('bin.vault.untrack')
+    @mock.patch('bin.vault.recover')
+    def test_recover_fofn(self, mock_recover, mock_remove, mock_file):
+        main(["__init__","recover", "--fofn", "mock_file"])
+        calls = [call(T.Path("/file1")), 
+                 call(T.Path("/file2"))]
+        mock_recover.assert_has_calls(calls)
+        mock_remove.assert_not_called()
+
+
     @mock.patch('bin.vault.untrack')
     def test_untrack(self, mock_untrack):
         main(["__init__","untrack" ,"/file1", "/file2"])
         mock_untrack.assert_called_with([T.Path("/file1"), T.Path("/file2")])
+
+    @mock.patch("builtins.open", new_callable=mock_open, read_data='/file1\n/file2\n')
+    @mock.patch('bin.vault.untrack')
+    def test_untrack(self, mock_untrack, mock_file):
+        main(["__init__","untrack" ,"--fofn", "mock_file"])
+        calls = [call(T.Path("/file1")), 
+                 call(T.Path("/file2"))]
+        mock_untrack.assert_has_calls(calls)

--- a/test/bin/vault/test_main.py
+++ b/test/bin/vault/test_main.py
@@ -100,9 +100,11 @@ class TestMain(unittest.TestCase):
     @mock.patch('bin.vault.add')
     def test_keep_fofn(self, mock_add, mock_remove, mock_file):
         main(["__init__","keep" ,"--fofn", "mock_file"])
-        calls = [call(Branch.Keep, [T.Path("/file1")]), 
-                 call(Branch.Keep, [T.Path("/file2")])]
-        mock_add.assert_has_calls(calls)
+        args = mock_add.call_args.args
+        files = list(args[1])
+        branch = args[0]
+        self.assertEqual(files , [T.Path("/file1"), T.Path("/file2")])
+        self.assertEqual(branch, Branch.Keep)
         mock_remove.assert_not_called()
 
 
@@ -247,9 +249,11 @@ class TestMain(unittest.TestCase):
     @mock.patch('bin.vault.add')
     def test_archive_fofn(self, mock_add, mock_remove, mock_file):
         main(["__init__","archive" ,"--fofn", "mock_file"])
-        calls = [call(Branch.Archive, [T.Path("/file1")]), 
-                 call(Branch.Archive, [T.Path("/file2")])]
-        mock_add.assert_has_calls(calls)
+        args = mock_add.call_args.args
+        files = list(args[1])
+        branch = args[0]
+        self.assertEqual(files , [T.Path("/file1"), T.Path("/file2")])
+        self.assertEqual(branch, Branch.Archive)
         mock_remove.assert_not_called()
 
     @mock.patch("builtins.open", new_callable=mock_open, read_data='/file1\n/file2')
@@ -257,9 +261,11 @@ class TestMain(unittest.TestCase):
     @mock.patch('bin.vault.add')
     def test_archive_stash_fofn(self, mock_add, mock_remove, mock_file):
         main(["__init__","archive" ,"--stash", "--fofn", "mock_file"])
-        calls = [call(Branch.Stash, [T.Path("/file1")]), 
-                 call(Branch.Stash, [T.Path("/file2")])]
-        mock_add.assert_has_calls(calls)
+        args = mock_add.call_args.args
+        files = list(args[1])
+        branch = args[0]
+        self.assertEqual(files , [T.Path("/file1"), T.Path("/file2")])
+        self.assertEqual(branch, Branch.Stash)
         mock_remove.assert_not_called()
 
 
@@ -291,11 +297,10 @@ class TestMain(unittest.TestCase):
     @mock.patch('bin.vault.recover')
     def test_recover_fofn(self, mock_recover, mock_remove, mock_file):
         main(["__init__","recover", "--fofn", "mock_file"])
-        calls = [call([T.Path("/file1")]), 
-                 call([T.Path("/file2")])]
-        mock_recover.assert_has_calls(calls)
+        args = mock_recover.call_args.args
+        files = list(args[0])
+        self.assertEqual(files , [T.Path("/file1"), T.Path("/file2")])
         mock_remove.assert_not_called()
-
 
     @mock.patch('bin.vault.untrack')
     def test_untrack(self, mock_untrack):
@@ -306,6 +311,6 @@ class TestMain(unittest.TestCase):
     @mock.patch('bin.vault.untrack')
     def test_untrack_fofn(self, mock_untrack, mock_file):
         main(["__init__","untrack" ,"--fofn", "mock_file"])
-        calls = [call([T.Path("/file1")]), 
-                 call([T.Path("/file2")])]
-        mock_untrack.assert_has_calls(calls)
+        args = mock_untrack.call_args.args
+        files = list(args[0])
+        self.assertEqual(files , [T.Path("/file1"), T.Path("/file2")])

--- a/test/bin/vault/test_main.py
+++ b/test/bin/vault/test_main.py
@@ -114,7 +114,7 @@ class TestMain(unittest.TestCase):
         mock_remove.assert_not_called()
         self._tmp.cleanup()
 
-    # Test for log warning message about symlink
+    # Test for log warning message about symlink in fofn case
     @mock.patch('bin.vault.untrack')
     def test_symlink_fofn(self, mock_untrack):
         self._tmp = TemporaryDirectory()

--- a/test/bin/vault/test_usage.py
+++ b/test/bin/vault/test_usage.py
@@ -211,3 +211,41 @@ class TestUsage(unittest.TestCase):
         except:
             success = True
         self.assertTrue(success)
+
+    def test_file_exception_fofn(self):
+        success = False
+        try:
+            args= parse_args(["archive", "--stash", "/file1", "/file2", "--fofn" "/file3"])
+        except:
+            success = True
+        self.assertTrue(success)
+
+        success = False
+        try:
+            args= parse_args(["archive", "--fofn" "/file3", "/file1", "/file2"])
+        except:
+            success = True
+        self.assertTrue(success)
+
+        success = False
+        try:
+            args= parse_args(["keep", "--fofn" "/file3", "/file1", "/file2"])
+        except:
+            success = True
+        self.assertTrue(success)
+
+        success = False
+        try:
+            args= parse_args(["recover", "--fofn" "/file3", "/file1", "/file2"])
+        except:
+            success = True
+        self.assertTrue(success)
+
+        success = False
+        try:
+            args= parse_args(["untrack", "--fofn" "/file3", "/file1", "/file2"])
+        except:
+            success = True
+        self.assertTrue(success)
+
+

--- a/test/bin/vault/test_usage.py
+++ b/test/bin/vault/test_usage.py
@@ -170,12 +170,7 @@ class TestUsage(unittest.TestCase):
 
     def test_untrack_view(self):
         args = ["untrack", "--view"]
-        success = False
-        try:
-            parse_args(args)
-        except:
-            success = True
-        self.assertTrue(success)
+        self.assertRaises(SystemExit, parse_args, args)
 
     def test_stash(self):
         args= parse_args(["archive", "--stash", "/file1", "/file2"])
@@ -183,69 +178,36 @@ class TestUsage(unittest.TestCase):
         self.assertEqual(args.files, expected)
 
     def test_stash_exception_keep(self):
-        success = False
-        try:
-            args= parse_args(["keep", "--stash", "/file1", "/file2"])
-        except:
-            success = True
-        self.assertTrue(success)
+        
+        args= ["keep", "--stash", "/file1", "/file2"]
+        self.assertRaises(SystemExit, parse_args, args)
         
     def test_stash_exception_view(self):
-        success = False
-        try:
-            args= parse_args(["archive", "--stash", "--view"])
-        except:
-            success = True
-        self.assertTrue(success)
+               
+        args= ["archive", "--stash", "--view"]
+        self.assertRaises(SystemExit, parse_args, args)
 
-        success = False
-        try:
-            args= parse_args(["archive", "--view", "--stash"])
-        except:
-            success = True
-        self.assertTrue(success)
+        args= ["archive", "--view", "--stash"]
+        self.assertRaises(SystemExit, parse_args, args)
 
-        success = False
-        try:
-            args= parse_args(["archive", "--stash"])
-        except:
-            success = True
-        self.assertTrue(success)
+        args= ["archive", "--stash"]
+        self.assertRaises(KeyError, parse_args, args)
 
     def test_file_exception_fofn(self):
-        success = False
-        try:
-            args= parse_args(["archive", "--stash", "/file1", "/file2", "--fofn" "/file3"])
-        except:
-            success = True
-        self.assertTrue(success)
+        
+        args= ["archive", "--stash", "/file1", "/file2", "--fofn" "/file3"]
+        self.assertRaises(SystemExit, parse_args, args)
+     
+        args= ["archive", "--fofn" "/file3", "/file1", "/file2"]
+        self.assertRaises(SystemExit, parse_args, args)
+        
+        args= ["keep", "--fofn" "/file3", "/file1", "/file2"]
+        self.assertRaises(SystemExit, parse_args, args)
 
-        success = False
-        try:
-            args= parse_args(["archive", "--fofn" "/file3", "/file1", "/file2"])
-        except:
-            success = True
-        self.assertTrue(success)
-
-        success = False
-        try:
-            args= parse_args(["keep", "--fofn" "/file3", "/file1", "/file2"])
-        except:
-            success = True
-        self.assertTrue(success)
-
-        success = False
-        try:
-            args= parse_args(["recover", "--fofn" "/file3", "/file1", "/file2"])
-        except:
-            success = True
-        self.assertTrue(success)
-
-        success = False
-        try:
-            args= parse_args(["untrack", "--fofn" "/file3", "/file1", "/file2"])
-        except:
-            success = True
-        self.assertTrue(success)
+        args= ["recover", "--fofn" "/file3", "/file1", "/file2"]
+        self.assertRaises(SystemExit, parse_args, args)
+        
+        args= ["untrack", "--fofn" "/file3", "/file1", "/file2"]
+        self.assertRaises(SystemExit, parse_args, args)
 
 


### PR DESCRIPTION
In all those instances where vault takes as input a file path (or a list of file paths), it will take an additional, optional flag  `--fofn` that will take a fofn filepath as argument.

Example:

```
vault keep --help
                | --view [CONTEXT] [--absolute]
                | --view-staged [CONTEXT] [--absolute]
                | [--stash] FILE [FILE...]
                | --fofn FILE
```

```
vault archive --help
                | --view [CONTEXT] [--absolute]
                | --view-staged [CONTEXT] [--absolute]
                | [--stash] FILE [FILE...]
                | --fofn FILE
```

```
vault recover --help
                | --view  [CONTEXT] [--absolute] 
                | --all 
                | FILE(s)...  
                | --fofn FILE
```

```
vault untrack --help
                | FILE(s)...  
                | --fofn FILE
```
