### PR TITLE
Resolve #21: File age is now the greater of mtime, atime and ctime.

### DIFF
--- a/api/persistence/models/file.py
+++ b/api/persistence/models/file.py
@@ -37,6 +37,7 @@ class File(persistence.base.File):
     key:T.Optional[T.Path]
     mtime:T.DateTime
     atime: T.DateTime
+    ctime: T.DateTime
     owner:idm.base.User
     group:idm.base.Group
 
@@ -52,6 +53,7 @@ class File(persistence.base.File):
                    key    = None,
                    mtime  = time.epoch(stat.st_mtime),
                    atime  = time.epoch(stat.st_atime),
+                   ctime  = time.epoch(stat.st_ctime),
                    owner  = idm.user(uid=stat.st_uid),
                    group  = idm.group(gid=stat.st_gid),
                    size   = stat.st_size)
@@ -64,6 +66,8 @@ class File(persistence.base.File):
                    path   = T.Path(record.path),
                    key    = T.Path(record.key) if record.key is not None else None,
                    mtime  = time.to_utc(record.mtime),
+                   atime  = time.to_utc(record.mtime),
+                   ctime  = time.to_utc(record.mtime),
                    owner  = idm.user(uid=record.owner),
                    group  = idm.group(gid=record.group_id),
                    size   = record.size)

--- a/api/persistence/models/file.py
+++ b/api/persistence/models/file.py
@@ -4,6 +4,7 @@ Copyright (c) 2020, 2022 Genome Research Limited
 Author:
     - Christopher Harrison <ch12@sanger.ac.uk>
     - Michael Grace <mg38@sanger.ac.uk>
+    - Sendu Bala <sb10@sanger.ac.uk>
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the

--- a/api/persistence/models/file.py
+++ b/api/persistence/models/file.py
@@ -66,6 +66,8 @@ class File(persistence.base.File):
                    path   = T.Path(record.path),
                    key    = T.Path(record.key) if record.key is not None else None,
                    mtime  = time.to_utc(record.mtime),
+                   # The db only records mtime, so we set a and c time to mtime
+                   # for now.
                    atime  = time.to_utc(record.mtime),
                    ctime  = time.to_utc(record.mtime),
                    owner  = idm.user(uid=record.owner),

--- a/bin/sandman/sweep.py
+++ b/bin/sandman/sweep.py
@@ -287,11 +287,15 @@ class Sweeper(Loggable):
         log = self.log
         log.debug(f"{file.path} is untracked")
 
-        if not VaultFile(vault, Branch.Limbo, file.path).can_add:
-            # Check we'll actually be able to soft-delete the file
-            # This only needs to be here, as this is the only time
-            # we interact with untracked files automatically
-            raise core.file.exception.UnactionableFile(f"{file.path} can't be actioned")
+        try:
+            if not VaultFile(vault, Branch.Limbo, file.path).can_add:
+                # Check we'll actually be able to soft-delete the file
+                # This only needs to be here, as this is the only time
+                # we interact with untracked files automatically
+                raise core.file.exception.UnactionableFile(f"{file.path} can't be actioned")
+        except core.vault.exception.VaultCorruption:
+            # this will be handled when the file is added to the branch
+            pass
 
         if _can_soft_delete(file):
             if file.locked:

--- a/bin/sandman/walk.py
+++ b/bin/sandman/walk.py
@@ -74,6 +74,7 @@ class File(file.BaseFile):
                            key    = None,
                            mtime  = time.epoch(stat.st_mtime),
                            atime  = time.epoch(stat.st_atime),
+                           ctime  = time.epoch(stat.st_ctime),
                            owner  = idm.user(uid=stat.st_uid),
                            group  = idm.group(gid=stat.st_gid),
                            size   = stat.st_size)
@@ -90,7 +91,7 @@ class File(file.BaseFile):
     @property
     def age(self) -> T.TimeDelta:
         self.restat()
-        return time.now() - max([self._file.mtime, self._file.atime])
+        return time.now() - max([self._file.mtime, self._file.atime, self._file.ctime])
 
     @property
     def locked(self) -> bool:

--- a/test/bin/sandman/test_sweep.py
+++ b/test/bin/sandman/test_sweep.py
@@ -262,7 +262,7 @@ class TestSweeper(unittest.TestCase):
     # Behavior:  Sweeper does not delete staged files
     @mock.patch('bin.sandman.walk.idm', new = dummy_idm)
     @mock.patch('bin.vault._create_vault')
-    def test_dryrun_staged(self, vault_mock):
+    def test_staged_not_deleted(self, vault_mock):
         vault_file_one = self.vault.add(Branch.Staged, self.file_one)
         self.file_one.unlink()
 

--- a/test/bin/sandman/test_sweep.py
+++ b/test/bin/sandman/test_sweep.py
@@ -568,10 +568,8 @@ class TestSweeper(unittest.TestCase):
         and then check if the email that is generated mentions
         the right information
         """
-        new_mtime: T.DateTime = time.now() - config.deletion.threshold + max(config.deletion.warnings) - time.delta(seconds = 1)
-        file.touch(self.file_one, mtime=new_mtime, atime=new_mtime)
-
-        dummy_walker = _DummyWalker([(self.vault, File.FromFS(self.file_one), None)])
+        new_time: T.DateTime = time.now() - config.deletion.threshold + max(config.deletion.warnings) - time.delta(seconds = 1)
+        dummy_walker = _DummyWalker([(self.vault, _DummyFile.FromFS(self.file_one, idm, ctime=new_time, mtime=new_time, atime=new_time), None)])
         dummy_persistence = _DummyPersistence(config.persistence, idm)
         MockMailer.file_path = T.Path(self._tmp.name).resolve() / "mail"
         Sweeper(dummy_walker, dummy_persistence, True, MockMailer) # this will make the email


### PR DESCRIPTION
Changed:
* bin/sandman/walk/File.age is now the greater of mtime, atime and ctime.
* partial de-linting and removal of some code duplication in test_sweep.py

Fixed:
* 2 of the test_sweep.py tests enabled by giving them unique names.