### PR TITLE
Minimum Group Owners Required for a Project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.vscode/

--- a/api/config.py
+++ b/api/config.py
@@ -1,9 +1,10 @@
 """
-Copyright (c) 2020, 2021 Genome Research Limited
+Copyright (c) 2020, 2021, 2022 Genome Research Limited
 
 Authors:
 * Christopher Harrison <ch12@sanger.ac.uk>
 * Piyush Ahuja <pa11@sanger.ac.uk>
+* Michael Grace <mg38@sanger.ac.uk>
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the
@@ -125,7 +126,10 @@ _schema = {
 
     "archive": {
         "threshold": _Setting(cast=int),
-        "handler": _Setting(cast=T.Path)}}
+        "handler": _Setting(cast=T.Path)
+    },
+    "min_group_owners": _Setting(cast=int, default=3)
+}
 
 
 def _validate(data: T.Dict, schema: T.Dict) -> bool:

--- a/core/vault.py
+++ b/core/vault.py
@@ -59,6 +59,10 @@ class exception(T.SimpleNamespace):
     class NoSuchVault(Exception):
         """ Raised whenever a vault doesn't exist where it's expected """
 
+    class MinimumNumberOfOwnersNotMet(Exception):
+        """Raised when an attempt to create a vault is made on a project
+        that doesn't meet the required minimum number of owners"""
+
 
 class _BaseBranch(Enum):
     """ Base vault branch/namespace enumeration """

--- a/eg/.vaultrc
+++ b/eg/.vaultrc
@@ -90,3 +90,8 @@ deletion:
 archive:
   threshold: 1000
   handler: /path/to/executable
+
+# min_group_owners defines how many owners must be defined
+# in a LDAP group before we can create a Vault/run sandman
+# on a project owned by that group
+min_group_owners: 3

--- a/test/bin/sandman/test_walk.py
+++ b/test/bin/sandman/test_walk.py
@@ -1,7 +1,9 @@
 """
-Copyright (c) 2021 Genome Research Limited
+Copyright (c) 2021, 2022 Genome Research Limited
 
-Author: Piyush Ahuja <pa11@sanger.ac.uk>
+Authors:
+    - Piyush Ahuja <pa11@sanger.ac.uk>
+    - Michael Grace <mg38@sanger.ac.uk>
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the
@@ -17,66 +19,16 @@ You should have received a copy of the GNU General Public License along
 with this program. If not, see https://www.gnu.org/licenses/
 """
 
-from bin.sandman.walk import FilesystemWalker
-from core.vault import exception as VaultExc
-from core import typing as T, idm as IdM
-from api.vault import Branch, Vault
-from unittest.mock import MagicMock
-from unittest import mock
 import unittest
 from tempfile import TemporaryDirectory
-import os
+from test.common import DummyIDM
+from unittest.mock import MagicMock
 
-
-class _DummyUser(IdM.base.User):
-    def __init__(self, uid):
-        self._id = uid
-
-    @property
-    def name(self):
-        raise NotImplementedError
-
-    @property
-    def email(self):
-        raise NotImplementedError
-
-
-class _DummyGroup(IdM.base.Group):
-    _owner: _DummyUser
-    _member: _DummyUser
-
-    def __init__(self, gid, owner, member=None):
-        self._id = gid
-        self._owner = owner
-        self._member = member or owner
-
-    @property
-    def name(self):
-        raise NotImplementedError
-
-    @property
-    def owners(self):
-        return iter([self._owner])
-
-    @property
-    def members(self):
-        yield self._member
-
-
-class _DummyIdM(IdM.base.IdentityManager):
-    _user: _DummyUser
-
-    def __init__(self, dummy_uid):
-        self._user = _DummyUser(dummy_uid)
-
-    def user(self, uid):
-        pass
-
-    def group(self, gid):
-        return _DummyGroup(gid, self._user)
-
-
-dummy_idm = _DummyIdM(1)
+from api.vault import Branch, Vault
+from bin.common import config
+from bin.sandman.walk import FilesystemWalker, InvalidVaultBases
+from core import typing as T
+from core.vault import exception as VaultExc
 
 
 class TestFileSystemWalker(unittest.TestCase):
@@ -91,6 +43,9 @@ class TestFileSystemWalker(unittest.TestCase):
                 |  +- file3
                 +- file1
         """
+
+        self._dummy_idm = DummyIDM(config)
+
         self._tmp = TemporaryDirectory()
         self.parent = path = T.Path(self._tmp.name).resolve() / "parent"
         self.some = path / "some"
@@ -115,7 +70,7 @@ class TestFileSystemWalker(unittest.TestCase):
         # Monkey patch Vault._find_root so that it returns the directory we
         # want
         Vault._find_root = MagicMock(return_value=self.parent)
-        self.vault = Vault(relative_to=self.file_one, idm=dummy_idm)
+        self.vault = Vault(relative_to=self.file_one, idm=self._dummy_idm)
 
     def tearDown(self):
         self._tmp.cleanup()
@@ -123,7 +78,6 @@ class TestFileSystemWalker(unittest.TestCase):
 
     # Behavior: A walk yields the correct status for the annotatd files, along
     # with the files
-    @mock.patch('bin.sandman.walk.idm', new=dummy_idm)
     def test_basic_case(self):
         # vault_mock =  MagicMock(return_value = self.parent)
         vault_file_one = self.vault.add(Branch.Keep, self.file_one)
@@ -131,7 +85,7 @@ class TestFileSystemWalker(unittest.TestCase):
         vault_file_three = self.vault.add(Branch.Limbo, self.file_three)
         self.file_three.unlink()
 
-        walker = FilesystemWalker(self.parent)
+        walker = FilesystemWalker(self.parent, idm=self._dummy_idm)
 
         files = {}
         for vault, file, status in walker.files():
@@ -151,7 +105,6 @@ class TestFileSystemWalker(unittest.TestCase):
         self.assertFalse(self.file_three in files)
 
     # Behavior: A walk yields the correct exceptions for corruped files
-    @mock.patch('bin.sandman.walk.idm', new=dummy_idm)
     def test_corruption_case(self):
         # vault_mock =  MagicMock(return_value = self.parent)
         vault_file_one = self.vault.add(Branch.Keep, self.file_one)
@@ -160,7 +113,7 @@ class TestFileSystemWalker(unittest.TestCase):
         self.file_one.unlink()
         self.file_two.unlink()
 
-        walker = FilesystemWalker(self.parent)
+        walker = FilesystemWalker(self.parent, idm=self._dummy_idm)
 
         files = {}
         for vault, file, status in walker.files():
@@ -181,14 +134,13 @@ class TestFileSystemWalker(unittest.TestCase):
             files[self.file_three], VaultExc.VaultCorruption))
 
     # Behavior: A walk yields the correct exceptions for Staged files
-    @mock.patch('bin.sandman.walk.idm', new=dummy_idm)
     def test_staged_case(self):
         # vault_mock =  MagicMock(return_value = self.parent)
         vault_file_one = self.vault.add(Branch.Staged, self.file_one)
         vault_file_two = self.vault.add(Branch.Staged, self.file_two)
         self.file_one.unlink()
 
-        walker = FilesystemWalker(self.parent)
+        walker = FilesystemWalker(self.parent, idm=self._dummy_idm)
 
         files = {}
         for vault, file, status in walker.files():
@@ -203,3 +155,25 @@ class TestFileSystemWalker(unittest.TestCase):
         self.assertFalse(self.file_one in files)
         self.assertFalse(isinstance(
             files[self.file_two], VaultExc.VaultCorruption))
+
+
+class TestWontRunSandman(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self._path = T.Path(self._tmp.name).resolve()
+        self._path.chmod(0o770)
+        Vault._find_root = lambda *_: self._path
+        Vault(self._path, idm=DummyIDM(
+            config, num_grp_owners=int(config.min_group_owners)))
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_group_not_enough_owners(self):
+        self.assertRaises(InvalidVaultBases, FilesystemWalker, self._path, idm=DummyIDM(
+            config, num_grp_owners=int(config.min_group_owners) - 1))
+
+    def test_group_has_enough_owners(self):
+        # shouldn't raise anything
+        FilesystemWalker(self._path, idm=DummyIDM(
+            config, num_grp_owners=int(config.min_group_owners)))

--- a/test/common.py
+++ b/test/common.py
@@ -1,0 +1,87 @@
+"""
+Copyright (c) 2022 Genome Research Limited
+
+Author: Michael Grace <mg38@sanger.ac.uk>
+
+This program is free software: you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see https://www.gnu.org/licenses/
+"""
+
+from core import typing as T
+from core.config import base as ConfigBase
+from core.idm import base as IDMBase
+
+
+class DummyUser(IDMBase.User):
+    def __init__(
+            self,
+            uid: int,
+            name: T.Optional[str] = None,
+            email: T.Optional[str] = None) -> None:
+        self._id: int = uid
+        self._name = name or f"Dummy User Name - uid: {self._id}"
+        self._email = email or f"Dummy User Email - uid: {self._id}"
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def email(self) -> T.Optional[str]:
+        return self._email
+
+
+class DummyGroup(IDMBase.Group):
+    def __init__(self,
+                 gid: int,
+                 num_grp_owners: int = 3,
+                 owner: IDMBase.User = DummyUser(1),
+                 member: T.Optional[IDMBase.User] = None) -> None:
+        self._id: int = gid
+        self._owner = owner
+        self._member: IDMBase.User = member or owner
+        self._num_owners: int = num_grp_owners
+
+    @property
+    def name(self) -> str:
+        return f"Dummy Group Name - gid: {self._id}"
+
+    @property
+    def members(self) -> T.Iterator[IDMBase.User]:
+        yield self._member
+
+    @property
+    def owners(self) -> T.Iterator[IDMBase.User]:
+        for _ in range(self._num_owners):
+            yield self._owner
+
+
+class DummyIDM(IDMBase.IdentityManager):
+    def __init__(self,
+                 _: ConfigBase.Config,
+                 num_grp_owners: int = 3,
+                 grp_owner: IDMBase.User = DummyUser(1),
+                 grp_member: T.Optional[IDMBase.User] = None) -> None:
+        self._num_grp_owners: int = num_grp_owners
+        self._grp_owner = grp_owner
+        self._grp_member = grp_member
+
+    def user(self, *, uid: int) -> DummyUser:
+        return DummyUser(uid)
+
+    def group(self, *, gid: int) -> DummyGroup:
+        return DummyGroup(
+            gid,
+            num_grp_owners=self._num_grp_owners,
+            owner=self._grp_owner,
+            member=self._grp_member)


### PR DESCRIPTION
Closes #3 

This introduces a configuration option `min_group_owners` that is the minimum number of owners defined in the identity manager (i.e. LDAP) the project group must have before vault/sandman can be used on the project